### PR TITLE
feat(docker): adding dockerized version of server

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:alpine
+LABEL maintainer=pascalwhoop
+LABEL name=powertac-server
+
+#adding all the needed dependencies, as alpine is a bloody lightweight
+RUN apk add --no-cache bash vim git maven python
+
+#TODO adding deps for weather-server and possible other components. It needs to be argued if ONE big container is a better idea or rather many small containers, one for each module.
+
+#docker usually acts mostly on the root filepath, as it's common for only one process to run inside of a container.
+WORKDIR /powertac
+COPY init.sh ./
+
+#download the server-distribution from github
+RUN chmod +x init.sh && \
+	mkdir data && \ 
+	git clone https://github.com/powertac/server-distribution 
+
+EXPOSE 8080 61616
+#and start it up with `mvn -Pweb2` as described in the docs on Github
+CMD /powertac/init.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,8 +17,7 @@ RUN chmod +x init.sh && \
 	git clone https://github.com/powertac/server-distribution	
 #build once, so the downloading of the maven archives doesn't happen every time we instantiate a new docker container
 RUN cd server-distribution && \
-	mvn package:package -Pweb2	
-
+	mvn package -Pweb2	
 EXPOSE 8080 61616
 #and start it up with `mvn -Pweb2` as described in the docs on Github
 CMD /powertac/init.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,10 @@ COPY init.sh ./
 #download the server-distribution from github
 RUN chmod +x init.sh && \
 	mkdir data && \ 
-	git clone https://github.com/powertac/server-distribution 
+	git clone https://github.com/powertac/server-distribution	
+#build once, so the downloading of the maven archives doesn't happen every time we instantiate a new docker container
+RUN cd server-distribution && \
+	mvn package:package -Pweb2	
 
 EXPOSE 8080 61616
 #and start it up with `mvn -Pweb2` as described in the docs on Github

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,0 +1,2 @@
+cd server-distribution
+mvn -Pweb2

--- a/docker/run_docker_image.sh
+++ b/docker/run_docker_image.sh
@@ -1,6 +1,6 @@
 #building an image locally, based on jdk-alpine (a lightweight image base with java)
 #this command builds an image and labels it. It uses the "Dockerfile" which is the default file name
-docker build --label powertac/server-distribution ./
+docker build --tag powertac/server-distribution ./
 
 #instantiates a container from the just built image and exposes the two ports. 
 docker run --name powertac  -v data:/powertac/data -e NB_UID=1000 -e NB_GID=1000 -p 8080:8080 -p 61616:61616 powertac/server-distribution 

--- a/docker/run_docker_image.sh
+++ b/docker/run_docker_image.sh
@@ -1,0 +1,6 @@
+#building an image locally, based on jdk-alpine (a lightweight image base with java)
+#this command builds an image and labels it. It uses the "Dockerfile" which is the default file name
+docker build --label powertac/server-distribution ./
+
+#instantiates a container from the just built image and exposes the two ports. 
+docker run --name powertac  -v data:/powertac/data -e NB_UID=1000 -e NB_GID=1000 -p 8080:8080 -p 61616:61616 powertac/server-distribution 


### PR DESCRIPTION
Adding a docker container for the server-distribution. Further
containers should be added for the weather module and other parts. I am
just starting out contributing so I'll take a while to get a grasp of
the overall structure.

With this, it is only required to have docker installed on the local machine.
Afterwards, executing the `run_docker_image.sh` will create an image and
start a new container based on this image. It will expose the two ports used
by the server and allow the access via `localhost:8080`. Further configurations
should be allowed, so that different variants can be started. I don't quiet understand
the difference yet between the cli and the web interface. Some input would
be appreciated.

Best regards,
